### PR TITLE
Update AdSets table output

### DIFF
--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -22,9 +22,13 @@ from config import numeric_internal_cols # Importar desde la raíz del proyecto
 from utils import aggregate_strings
 
 def _clean_audience_string(aud_str):
-    parts = [p.strip() for p in str(aud_str).split('|')]
-    cleaned = [re.sub(r'^\s*\d+\s*:\s*', '', p) for p in parts]
-    return ' | '.join(cleaned)
+    """Remove numeric prefixes from audience names and unify separators."""
+    if aud_str is None or str(aud_str).strip() == "-":
+        return "-"
+    # Split on '|' or ',' and strip whitespace
+    parts = re.split(r"\s*[|,]\s*", str(aud_str))
+    cleaned = [re.sub(r"^\s*\d+\s*:\s*", "", p).strip() for p in parts if p]
+    return " | ".join(cleaned)
 
 
 # ============================================================
@@ -1257,7 +1261,13 @@ def _generar_tabla_bitacora_top_adsets(df_daily_agg, bitacora_periods_list, acti
             column_order = ['Campaña','AdSet','Días Act','Públicos Incluidos','Públicos Excluidos'] + metric_labels
             df_display = df_display[[c for c in column_order if c in df_display.columns]]
             num_cols = [c for c in df_display.columns if c not in ['Campaña','AdSet','Públicos Incluidos','Públicos Excluidos']]
-            _format_dataframe_to_markdown(df_display, f"Top {top_n} AdSets Bitácora - {label}", log_func, numeric_cols_for_alignment=num_cols)
+            _format_dataframe_to_markdown(
+                df_display,
+                f"Top {top_n} AdSets Bitácora - {label}",
+                log_func,
+                numeric_cols_for_alignment=num_cols,
+                max_col_width=45,
+            )
             any_table = True
 
     if not any_table:

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -52,6 +52,8 @@ def test_top_ads_basic_columns(capsys):
 
 def test_clean_audience_string():
     assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'
+    # Also handle comma separated values
+    assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1 | Aud2'
 
 
 def test_top_adsets_weekly_table(capsys):


### PR DESCRIPTION
## Summary
- clean audience names from numeric prefixes
- truncate AdSets table columns for consistent formatting
- extend audience cleaning tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6359c2388332ab3d6fa64b881412