### PR TITLE
Update value mapping and fallback

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,9 +47,8 @@ norm_map = {
                  normalize('Información de pago agregada')],                                                            # Nuevo mapeo
 
     'purchases': [normalize('Compras'), normalize('Website purchases')], # Compras (que ahora se llamará "Ventas" en el reporte)
-    'value': [normalize('Valor de conversión de compras'), normalize('Website purchase conversion value')], # Valor (que se llamará "Total Ventas")
-    
     'value_avg': [normalize('Valor de conversión de compras promedio'), normalize('Average purchase conversion value')],
+    'value': [normalize('Valor de conversión de compras'), normalize('Website purchase conversion value')], # Valor (que se llamará "Total Ventas")
     'roas': [normalize('ROAS (retorno de la inversión en publicidad) de compras en el sitio web'), normalize('ROAS (retorno de la inversión en publicidad) de compras'), normalize('Website purchase ROAS (return on ad spend)'), normalize('Purchase ROAS (return on ad spend)')],
     'cpa': [normalize('Costo por compra'), normalize('Cost per website purchase'), normalize('Cost per Purchase')],
     

--- a/data_processing/loaders.py
+++ b/data_processing/loaders.py
@@ -167,6 +167,11 @@ def _cargar_y_preparar_datos(input_files, status_queue, selected_campaign):
                         log_and_update(f"     !!! Error robust_numeric_conversion en '{col_num}': {e_num_conv}. Usando pd.to_numeric.");
                         df_renamed[col_num] = pd.to_numeric(df_renamed[col_num], errors='coerce')
             log_and_update("     Limpieza numérica OK.")
+
+            # If the total value column is missing, derive it from the average value
+            if 'value' not in df_renamed.columns and {'value_avg', 'purchases'}.issubset(df_renamed.columns):
+                log_and_update("     Columna 'value' no encontrada. Calculando a partir de 'value_avg' * 'purchases'.")
+                df_renamed['value'] = df_renamed['value_avg'] * df_renamed['purchases']
             
             def extract_ad_name_safe(txt):
                 """Clean ad name removing pipes and normalizing."""

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -22,9 +22,13 @@ from config import numeric_internal_cols # Importar desde la raíz del proyecto
 from utils import aggregate_strings
 
 def _clean_audience_string(aud_str):
-    parts = [p.strip() for p in str(aud_str).split('|')]
-    cleaned = [re.sub(r'^\s*\d+\s*:\s*', '', p) for p in parts]
-    return ' | '.join(cleaned)
+    """Remove numeric prefixes from audience names and unify separators."""
+    if aud_str is None or str(aud_str).strip() == "-":
+        return "-"
+    # Split on '|' or ',' and strip whitespace
+    parts = re.split(r"\s*[|,]\s*", str(aud_str))
+    cleaned = [re.sub(r"^\s*\d+\s*:\s*", "", p).strip() for p in parts if p]
+    return " | ".join(cleaned)
 
 
 # ============================================================
@@ -1202,7 +1206,13 @@ def _generar_tabla_bitacora_top_adsets(df_daily_agg, bitacora_periods_list, acti
         if active_days_total_adset_df is not None and not active_days_total_adset_df.empty:
             merge_cols = [c for c in group_cols if c in active_days_total_adset_df.columns]
             if merge_cols:
-                ranking_df = pd.merge(ranking_df, active_days_total_adset_df[merge_cols + ['Días_Activo_Total']], on=merge_cols, how='left')
+                dedup_active = active_days_total_adset_df.drop_duplicates(subset=merge_cols)
+                ranking_df = pd.merge(
+                    ranking_df,
+                    dedup_active[merge_cols + ['Días_Activo_Total']],
+                    on=merge_cols,
+                    how='left',
+                )
         ranking_df = ranking_df.sort_values('rank_score', ascending=False).head(top_n)
         ranking_df['Días_Activo_Total'] = ranking_df.get('Días_Activo_Total', 0).fillna(0).astype(int)
     else:
@@ -1256,8 +1266,15 @@ def _generar_tabla_bitacora_top_adsets(df_daily_agg, bitacora_periods_list, acti
             df_display = pd.DataFrame(table_rows)
             column_order = ['Campaña','AdSet','Días Act','Públicos Incluidos','Públicos Excluidos'] + metric_labels
             df_display = df_display[[c for c in column_order if c in df_display.columns]]
+            df_display = df_display.drop_duplicates()
             num_cols = [c for c in df_display.columns if c not in ['Campaña','AdSet','Públicos Incluidos','Públicos Excluidos']]
-            _format_dataframe_to_markdown(df_display, f"Top {top_n} AdSets Bitácora - {label}", log_func, numeric_cols_for_alignment=num_cols)
+            _format_dataframe_to_markdown(
+                df_display,
+                f"Top {top_n} AdSets Bitácora - {label}",
+                log_func,
+                numeric_cols_for_alignment=num_cols,
+                max_col_width=45,
+            )
             any_table = True
 
     if not any_table:

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -15,6 +15,7 @@ This document lists the columns present in the imported Excel reports and how th
 | Impresiones | impr | numeric | mapped via `norm_map` |
 | Alcance | reach | numeric | mapped via `norm_map` |
 | Frecuencia | freq | numeric | mapped via `norm_map` |
+| Valor de conversión de compras | value | numeric | mapped via `norm_map`; if absent, derived from `Valor de conversión de compras promedio` × `Compras` |
 | Valor de conversión de compras promedio | value_avg | numeric | mapped via `norm_map` |
 | Compras | purchases | numeric | mapped via `norm_map` |
 | Visitas a la página de destino | visits | numeric | mapped via `norm_map` |

--- a/docs/excel_column_list.md
+++ b/docs/excel_column_list.md
@@ -14,6 +14,7 @@ Entrega del anuncio
 Impresiones
 Alcance
 Frecuencia
+Valor de conversión de compras
 Valor de conversión de compras promedio
 Compras
 Visitas a la página de destino

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,21 @@
+import queue
+import pandas as pd
+from data_processing.loaders import _cargar_y_preparar_datos
+
+def test_value_fallback_from_avg(tmp_path):
+    df = pd.DataFrame({
+        'Día': ['2025-06-01', '2025-06-02'],
+        'Nombre de la campaña': ['Camp', 'Camp'],
+        'Nombre del conjunto de anuncios': ['Set', 'Set'],
+        'Valor de conversión de compras promedio': [50, 50],
+        'Compras': [2, 3],
+    })
+    file_path = tmp_path / 'data.xlsx'
+    df.to_excel(file_path, index=False)
+
+    q = queue.SimpleQueue()
+    result, _, _ = _cargar_y_preparar_datos([str(file_path)], q, '__ALL__')
+    assert 'value' in result.columns
+    expected = df['Valor de conversión de compras promedio'].iloc[1] * df['Compras'].iloc[1]
+    assert result['value'].iloc[0] == expected
+

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -52,6 +52,8 @@ def test_top_ads_basic_columns(capsys):
 
 def test_clean_audience_string():
     assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'
+    # Also handle comma separated values
+    assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1 | Aud2'
 
 
 def test_top_adsets_weekly_table(capsys):
@@ -80,6 +82,31 @@ def test_top_adsets_weekly_table(capsys):
     output = "\n".join(logs)
     assert 'Top 1 AdSets Bitácora - Semana actual' in output
     assert 'Días Act' in output
+
+
+def test_top_adsets_deduplication():
+    df = pd.DataFrame({
+        'date': pd.to_datetime(['2024-06-01', '2024-06-02']),
+        'Campaign': ['Camp', 'Camp'],
+        'AdSet': ['Set', 'Set'],
+        'spend': [10, 15],
+        'impr': [100, 150],
+        'reach': [90, 130],
+        'purchases': [1, 1],
+        'visits': [10, 12],
+        'value': [20, 25],
+    })
+    periods = [(datetime(2024, 6, 1), datetime(2024, 6, 2), 'Semana actual')]
+    # Active days with duplicate row
+    active = pd.DataFrame({
+        'Campaign': ['Camp', 'Camp'],
+        'AdSet': ['Set', 'Set'],
+        'Días_Activo_Total': [2, 2],
+    })
+    logs = []
+    _generar_tabla_bitacora_top_adsets(df, periods, active, logs.append, '$', top_n=1)
+    row_lines = [l for l in logs if l.startswith('| Camp ')]
+    assert len(row_lines) == 1
 
 
 def test_top_campaigns_weekly_table(capsys):


### PR DESCRIPTION
## Summary
- derive `value` from `value_avg` when the direct column is absent
- ensure `value_avg` column maps before `value`
- document `Valor de conversión de compras` mapping and list in Excel docs
- add regression test for fallback logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6359c2388332ab3d6fa64b881412