### PR TITLE
Fix audience delimiter and sanitize names

### DIFF
--- a/data_processing/aggregators.py
+++ b/data_processing/aggregators.py
@@ -42,8 +42,8 @@ def _agregar_datos_diarios(df_combined, status_queue, selected_adsets=None):
             'visits':'sum','clicks_out':'sum', 'rv3':'sum','rv25':'sum','rv75':'sum','rv100':'sum',
             'attention':'sum','interest':'sum','deseo':'sum','addcart':'sum','checkout':'sum',
             'rtime':'mean','freq':'mean','roas':'mean','cpa':'mean',
-            'Públicos In':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
-            'Públicos Ex':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
+            'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None),
+            'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None),
             'Entrega':lambda x:aggregate_strings(x,separator='|',max_len=50)
         }
         actual_agg_dict={k:v for k,v in agg_dict_base.items() if k in df_filtered.columns}

--- a/data_processing/loaders.py
+++ b/data_processing/loaders.py
@@ -189,8 +189,8 @@ def _cargar_y_preparar_datos(input_files, status_queue, selected_campaign):
                     log_and_update(f"     Adv: error extracting ad name: {e_extract}")
                     return ""
 
-            df_renamed['Campaign']=df_renamed.get('campaign', pd.Series(dtype=str)).fillna('(No Campaign)').astype(str).apply(normalize)
-            df_renamed['AdSet']=df_renamed.get('adset', pd.Series(dtype=str)).fillna('(No AdSet)').astype(str).apply(normalize)
+            df_renamed['Campaign']=df_renamed.get('campaign', pd.Series(dtype=str)).fillna('(No Campaign)').astype(str).str.replace('|','').apply(normalize)
+            df_renamed['AdSet']=df_renamed.get('adset', pd.Series(dtype=str)).fillna('(No AdSet)').astype(str).str.replace('|','').apply(normalize)
             
             if 'ad' in df_renamed.columns:
                 df_renamed['Anuncio']=df_renamed['ad'].apply(extract_ad_name_safe)
@@ -199,12 +199,12 @@ def _cargar_y_preparar_datos(input_files, status_queue, selected_campaign):
 
             # MODIFICACIÓN para 'Públicos In' y 'Públicos Ex'
             if 'aud_in' in df_renamed.columns:
-                df_renamed['Públicos In'] = df_renamed['aud_in'].fillna('').astype(str).apply(normalize)
+                df_renamed['Públicos In'] = df_renamed['aud_in'].fillna('').astype(str).str.replace('|','').apply(normalize)
             else:
                 df_renamed['Públicos In'] = pd.Series('', index=df_renamed.index, dtype=str).apply(normalize)
 
             if 'aud_ex' in df_renamed.columns:
-                df_renamed['Públicos Ex'] = df_renamed['aud_ex'].fillna('').astype(str).apply(normalize)
+                df_renamed['Públicos Ex'] = df_renamed['aud_ex'].fillna('').astype(str).str.replace('|','').apply(normalize)
             else:
                 df_renamed['Públicos Ex'] = pd.Series('', index=df_renamed.index, dtype=str).apply(normalize)
 

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -28,7 +28,7 @@ def _clean_audience_string(aud_str):
     # Split on '|' or ',' and strip whitespace
     parts = re.split(r"\s*[|,]\s*", str(aud_str))
     cleaned = [re.sub(r"^\s*\d+\s*:\s*", "", p).strip() for p in parts if p]
-    return " | ".join(cleaned)
+    return ", ".join(cleaned)
 
 
 # Metric labels used in the Top tables
@@ -655,9 +655,9 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
         'impr':'sum','reach':'sum','visits':'sum','rv3':'sum','rv25':'sum','rv75':'sum','rv100':'sum',
         'rtime':'mean','frequency':'mean','cpm':'mean','ctr':'mean','ctr_out':'mean',
         'roas':'mean','cpa':'mean',
-        'rv25_pct':'mean','rv75_pct':'mean','rv100_pct':'mean', 
-        'Públicos In':lambda x:aggregate_strings(x,separator=' | ',max_len=None), 
-        'Públicos Ex':lambda x:aggregate_strings(x,separator=' | ',max_len=None)
+        'rv25_pct':'mean','rv75_pct':'mean','rv100_pct':'mean',
+        'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None),
+        'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None)
     }
     agg_dict_ad_global_available={k:v for k,v in agg_dict_base.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_ad_global_available: log_func("Adv: No hay columnas para agregación global Ads."); return
@@ -914,8 +914,8 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         'impr':'sum','reach':'sum','rtime':'mean','rv3':'sum',
         'rv25':'sum','rv75':'sum','rv100':'sum','thruplays':'sum','puja':'mean',
         'url_final':lambda x: aggregate_strings(x, separator=' | ', max_len=None),
-        'Públicos In': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
-        'Públicos Ex': lambda x: aggregate_strings(x, separator=' | ', max_len=None)
+        'Públicos In': lambda x: aggregate_strings(x, separator=', ', max_len=None),
+        'Públicos Ex': lambda x: aggregate_strings(x, separator=', ', max_len=None)
     }
     agg_dict_available={k:v for k,v in agg_dict.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_available or 'spend' not in agg_dict_available or 'impr' not in agg_dict_available: 
@@ -1056,8 +1056,8 @@ def _generar_tabla_bitacora_top_entities(
         'rv3': 'sum', 'rv25': 'sum', 'rv75': 'sum', 'rv100': 'sum', 'rtime': 'mean',
         'puja': 'mean', 'interacciones': 'sum', 'comentarios': 'sum',
         'url_final': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
-        'Públicos In': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
-        'Públicos Ex': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
+        'Públicos In': lambda x: aggregate_strings(x, separator=', ', max_len=None),
+        'Públicos Ex': lambda x: aggregate_strings(x, separator=', ', max_len=None),
     }
 
     period_metrics = {}

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -57,9 +57,9 @@ def test_top_ads_basic_columns(capsys):
     assert 'Ventas' in output
 
 def test_clean_audience_string():
-    assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'
+    assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1, Aud2'
     # Also handle comma separated values
-    assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1 | Aud2'
+    assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1, Aud2'
 
 
 def test_top_adsets_weekly_table(capsys):

--- a/utils.py
+++ b/utils.py
@@ -8,9 +8,13 @@ import numpy as np
 # FUNCIONES DE UTILIDAD GENERAL
 # ============================================================
 def normalize(text):
-    if not isinstance(text, str): text = str(text)
-    s = re.sub(r"\s*\([^)]*\)$", "", text); s = unicodedata.normalize('NFKD', s)
-    s = "".join(c for c in s if not unicodedata.combining(c)); return s.lower().strip()
+    if not isinstance(text, str):
+        text = str(text)
+    s = re.sub(r"\s*\([^)]*\)$", "", text)
+    s = s.replace('|', '')
+    s = unicodedata.normalize('NFKD', s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return s.lower().strip()
 
 def aggregate_strings(series, separator=', ', max_len=70):
     if series.empty or series.isnull().all(): return '-'


### PR DESCRIPTION
## Summary
- strip `|` from campaign, adset, ad and audience names when loading files
- ensure normalized text removes `|`
- separate multiple audiences with commas
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c268ed9008332b4857f65af544562