### PR TITLE
Fix audience separator logic

### DIFF
--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -57,9 +57,11 @@ def test_top_ads_basic_columns(capsys):
     assert 'Ventas' in output
 
 def test_clean_audience_string():
-    assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1 | Aud2'
+    assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1, Aud2'
     # Also handle comma separated values
-    assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1 | Aud2'
+    assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1, Aud2'
+    # Numeric prefixes without explicit separator
+    assert _clean_audience_string('123:Aud1 456:Aud2') == 'Aud1, Aud2'
 
 
 def test_top_adsets_weekly_table(capsys):

--- a/utils.py
+++ b/utils.py
@@ -16,10 +16,40 @@ def normalize(text):
     s = "".join(c for c in s if not unicodedata.combining(c))
     return s.lower().strip()
 
+def _split_clean_items(value):
+    """Split audience or name strings on separators.
+
+    Besides splitting on ``|`` or `,` this helper also treats occurrences of a
+    numeric prefix followed by ``:`` (e.g. ``123:Name``) as delimiters. The
+    numeric portion is removed so only the clean name remains. Any stray ``|`` or
+    commas are stripped from the resulting parts.
+    """
+    if value is None:
+        return []
+
+    s = str(value)
+    # Replace numeric prefixes like ``123:`` with a pipe so they work as
+    # separators when splitting below.
+    s = re.sub(r"(?:^|\s)\d+\s*:", "|", s)
+
+    parts = re.split(r"\s*[|,]\s*", s)
+    cleaned = []
+    for p in parts:
+        name = p.strip().replace("|", "").replace(",", "")
+        if name:
+            cleaned.append(name)
+    return cleaned
+
+
 def aggregate_strings(series, separator=', ', max_len=70):
-    if series.empty or series.isnull().all(): return '-'
-    unique_strings = series.astype(str).dropna().str.strip().loc[lambda s: s.str.len() > 0].unique()
-    if unique_strings.size == 0: return '-'
+    if series.empty or series.isnull().all():
+        return '-'
+    items = []
+    for val in series.astype(str).dropna():
+        items.extend(_split_clean_items(val))
+    unique_strings = pd.unique([s.strip() for s in items if s.strip()])
+    if unique_strings.size == 0:
+        return '-'
     result = separator.join(unique_strings)
     if max_len is not None and len(result) > max_len:
         result = result[:max_len-3] + '...'


### PR DESCRIPTION
## Summary
- parse numeric prefixes when cleaning audience strings
- use updated helper `_split_clean_items` throughout loaders and reports
- test handling of audiences separated only by digits

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3d5167448332bc28faa2cfe2650e