### PR TITLE
Fix audience string cleaning

### DIFF
--- a/data_processing/aggregators.py
+++ b/data_processing/aggregators.py
@@ -42,8 +42,8 @@ def _agregar_datos_diarios(df_combined, status_queue, selected_adsets=None):
             'visits':'sum','clicks_out':'sum', 'rv3':'sum','rv25':'sum','rv75':'sum','rv100':'sum',
             'attention':'sum','interest':'sum','deseo':'sum','addcart':'sum','checkout':'sum',
             'rtime':'mean','freq':'mean','roas':'mean','cpa':'mean',
-            'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None),
-            'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None),
+            'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None, remove_commas=False),
+            'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None, remove_commas=False),
             'Entrega':lambda x:aggregate_strings(x,separator='|',max_len=50)
         }
         actual_agg_dict={k:v for k,v in agg_dict_base.items() if k in df_filtered.columns}

--- a/data_processing/loaders.py
+++ b/data_processing/loaders.py
@@ -183,7 +183,7 @@ def _cargar_y_preparar_datos(input_files, status_queue, selected_campaign):
                         part = s.split('🆔')[-1].strip()
                         if part:
                             s = part
-                    items = _split_clean_items(s)
+                    items = _split_clean_items(s, remove_commas=True)
                     cleaned = ', '.join(items)
                     return normalize(cleaned)
                 except Exception as e_extract:
@@ -191,7 +191,7 @@ def _cargar_y_preparar_datos(input_files, status_queue, selected_campaign):
                     return ""
 
             def clean_name_list(val):
-                items = _split_clean_items(val)
+                items = _split_clean_items(val, remove_commas=True)
                 return ', '.join(items)
 
             df_renamed['Campaign'] = (

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -22,29 +22,34 @@ from config import numeric_internal_cols # Importar desde la raíz del proyecto
 from utils import aggregate_strings
 
 def _clean_audience_string(aud_str):
-    """Remove numeric prefixes and commas from audience names.
+    """Remove numeric prefixes from audience names and normalize separators.
 
     Audience strings may contain multiple audiences separated by either
-    ``|`` or `,`. Commas inside the actual audience names can lead to
-    confusion when several audiences are joined together. This helper
-    normalizes the string by:
+    ``|`` or `,`. This helper normalizes the string by:
 
     1. Splitting on ``|`` or `,` to detect individual audiences.
     2. Removing any leading numeric identifiers (``123:Name`` -> ``Name``).
-    3. Stripping commas from within each audience name.
-    4. Joining the cleaned parts using a comma so the output uses ``","``
-       only as a separator between distinct audience names.
+    3. Joining the cleaned parts using a comma so the output uses ``","``
+       only as a separator between distinct audience names. Commas inside
+       individual audience names are preserved.
     """
     if aud_str is None or str(aud_str).strip() == "-":
         return "-"
 
-    parts = re.split(r"\s*[|,]\s*", str(aud_str))
+    text = str(aud_str)
+    # Insert a separator before each new audience detected by the pattern
+    # ``digits:`` when preceded by whitespace. This allows splitting on the
+    # separator regardless of whether the original string used commas, pipes or
+    # just spaces between audiences.
+    text = re.sub(r"(?<=\s)(?=\d+\s*:)", "|", text)
+
+    parts = re.split(r"\s*[|,]\s*", text)
     cleaned = []
     for p in parts:
         if not p:
             continue
         name = re.sub(r"^\s*\d+\s*:\s*", "", p).strip()
-        name = name.replace(",", "").replace("|", "")
+        name = name.replace("|", "")
         if name:
             cleaned.append(name)
 
@@ -676,8 +681,8 @@ def _generar_analisis_ads(df_combined, df_daily_agg, active_days_total_ad_df, lo
         'rtime':'mean','frequency':'mean','cpm':'mean','ctr':'mean','ctr_out':'mean',
         'roas':'mean','cpa':'mean',
         'rv25_pct':'mean','rv75_pct':'mean','rv100_pct':'mean',
-        'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None),
-        'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None)
+        'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None, remove_commas=False),
+        'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None, remove_commas=False)
     }
     agg_dict_ad_global_available={k:v for k,v in agg_dict_base.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_ad_global_available: log_func("Adv: No hay columnas para agregación global Ads."); return
@@ -934,8 +939,8 @@ def _generar_tabla_top_ads_historico(df_daily_agg, active_days_total_ad_df, log_
         'impr':'sum','reach':'sum','rtime':'mean','rv3':'sum',
         'rv25':'sum','rv75':'sum','rv100':'sum','thruplays':'sum','puja':'mean',
         'url_final':lambda x: aggregate_strings(x, separator=' | ', max_len=None),
-        'Públicos In': lambda x: aggregate_strings(x, separator=', ', max_len=None),
-        'Públicos Ex': lambda x: aggregate_strings(x, separator=', ', max_len=None)
+        'Públicos In': lambda x: aggregate_strings(x, separator=', ', max_len=None, remove_commas=False),
+        'Públicos Ex': lambda x: aggregate_strings(x, separator=', ', max_len=None, remove_commas=False)
     }
     agg_dict_available={k:v for k,v in agg_dict.items() if k in df_daily_agg_copy.columns} 
     if not agg_dict_available or 'spend' not in agg_dict_available or 'impr' not in agg_dict_available: 
@@ -1076,8 +1081,8 @@ def _generar_tabla_bitacora_top_entities(
         'rv3': 'sum', 'rv25': 'sum', 'rv75': 'sum', 'rv100': 'sum', 'rtime': 'mean',
         'puja': 'mean', 'interacciones': 'sum', 'comentarios': 'sum',
         'url_final': lambda x: aggregate_strings(x, separator=' | ', max_len=None),
-        'Públicos In': lambda x: aggregate_strings(x, separator=', ', max_len=None),
-        'Públicos Ex': lambda x: aggregate_strings(x, separator=', ', max_len=None),
+        'Públicos In': lambda x: aggregate_strings(x, separator=', ', max_len=None, remove_commas=False),
+        'Públicos Ex': lambda x: aggregate_strings(x, separator=', ', max_len=None, remove_commas=False),
     }
 
     period_metrics = {}

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -60,6 +60,14 @@ def test_clean_audience_string():
     assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1, Aud2'
     # Also handle comma separated values
     assert _clean_audience_string('123:Aud1, 456:Aud2') == 'Aud1, Aud2'
+    # Should detect new audiences separated only by spaces
+    sample = '120219213417610120:IG Engagers 60d 120982364718293172:Web Visitors 30d'
+    expected = 'IG Engagers 60d, Web Visitors 30d'
+    assert _clean_audience_string(sample) == expected
+    # Preserve commas inside audience names
+    comma_sample = '123:New York, USA 456:Web Visitors 30d'
+    comma_expected = 'New York, USA, Web Visitors 30d'
+    assert _clean_audience_string(comma_sample) == comma_expected
 
 
 def test_top_adsets_weekly_table(capsys):

--- a/utils.py
+++ b/utils.py
@@ -16,25 +16,27 @@ def normalize(text):
     s = "".join(c for c in s if not unicodedata.combining(c))
     return s.lower().strip()
 
-def _split_clean_items(value):
-    """Split a string on ``|`` or `,` and remove those characters from each part."""
+def _split_clean_items(value, remove_commas=False):
+    """Split a string on ``|`` or `,`` and optionally strip commas from parts."""
     if value is None:
         return []
     parts = re.split(r"\s*[|,]\s*", str(value))
     cleaned = []
     for p in parts:
-        name = p.strip().replace("|", "").replace(",", "")
+        name = p.strip().replace("|", "")
+        if remove_commas:
+            name = name.replace(",", "")
         if name:
             cleaned.append(name)
     return cleaned
 
 
-def aggregate_strings(series, separator=', ', max_len=70):
+def aggregate_strings(series, separator=', ', max_len=70, remove_commas=False):
     if series.empty or series.isnull().all():
         return '-'
     items = []
     for val in series.astype(str).dropna():
-        items.extend(_split_clean_items(val))
+        items.extend(_split_clean_items(val, remove_commas=remove_commas))
     unique_strings = pd.unique([s.strip() for s in items if s.strip()])
     if unique_strings.size == 0:
         return '-'


### PR DESCRIPTION
## Summary
- keep commas inside audience names
- only drop commas for Campaign, AdSet and Ad names
- add test for comma preservation

## Testing
- `pip install openpyxl`
- `pip install numpy pandas`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c56de7c90833298a0a54ae48ca628