### PR TITLE
Fix deprecation warning in utils aggregate_strings

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -35,7 +35,9 @@ def aggregate_strings(series, separator=', ', max_len=70):
     items = []
     for val in series.astype(str).dropna():
         items.extend(_split_clean_items(val))
-    unique_strings = pd.unique([s.strip() for s in items if s.strip()])
+    # Pass a numpy array to ``pd.unique`` to avoid deprecation warnings
+    cleaned = np.array([s.strip() for s in items if s.strip()])
+    unique_strings = pd.unique(cleaned)
     if unique_strings.size == 0:
         return '-'
     result = separator.join(unique_strings)


### PR DESCRIPTION
## Summary
- fix `pd.unique` usage to avoid FutureWarning in `aggregate_strings`

## Testing
- `PYTHONPATH=. pytest -q -W error::FutureWarning`


------
https://chatgpt.com/codex/tasks/task_e_684c6ed4ec1c8332a508a8326b617085