### PR TITLE
Add new campaign metrics and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ desired number of months.
 
 Generated reports are plain text files where tables use a semicolon (`;`) as the delimiter for each cell. This ensures data can be imported directly into spreadsheet tools. See `docs/report_format.md` for details.
 
+Recent updates add support for extra fields such as campaign and ad set budgets, objectives and purchase types. These appear in the bitácora tables if present in the source files.
+
 ## Contributing
 
 Pull requests that introduce useful scripts, improve documentation, or help define the project structure are welcome. Feel free to open issues to discuss ideas or report problems.

--- a/config.py
+++ b/config.py
@@ -78,6 +78,11 @@ norm_map = {
         normalize('Post comments'),
         normalize('Comentarios'),  # nombre corto
     ],
+    'delivery_general_status': [normalize('Estado de la entrega')],
+    'campaign_budget': [normalize('presupuesto Campaña'), normalize('Presupuesto de la campaña')],
+    'adset_budget': [normalize('Presupuesto Adset'), normalize('Presupuesto del conjunto de anuncios')],
+    'objective': [normalize('Objetivo'), normalize('Objective')],
+    'purchase_type': [normalize('Tipo de compra')],
 }
 
 numeric_internal_cols = [
@@ -90,6 +95,7 @@ numeric_internal_cols = [
     'value', 'value_avg', 'roas', 'cpa', 'ncpa', 'aov', 'cvr',
     'rv3', 'rv25', 'rv75', 'rv100', 'rtime' # Video
     ,'thruplays','puja','interacciones','comentarios'
+    ,'campaign_budget','adset_budget'
 ]
 
 # Símbolos de moneda preferidos (puedes expandir esto)

--- a/data_processing/aggregators.py
+++ b/data_processing/aggregators.py
@@ -42,6 +42,10 @@ def _agregar_datos_diarios(df_combined, status_queue, selected_adsets=None):
             'visits':'sum','clicks_out':'sum', 'rv3':'sum','rv25':'sum','rv75':'sum','rv100':'sum',
             'attention':'sum','interest':'sum','deseo':'sum','addcart':'sum','checkout':'sum',
             'rtime':'mean','freq':'mean',
+            'campaign_budget':'mean','adset_budget':'mean',
+            'objective':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
+            'purchase_type':lambda x:aggregate_strings(x,separator=' | ',max_len=None),
+            'delivery_general_status':lambda x:aggregate_strings(x,separator='|',max_len=50),
             'Públicos In':lambda x:aggregate_strings(x,separator=', ',max_len=None),
             'Públicos Ex':lambda x:aggregate_strings(x,separator=', ',max_len=None),
             'Entrega':lambda x:aggregate_strings(x,separator='|',max_len=50)

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -68,7 +68,8 @@ def _remove_commas(text):
 # Metric labels used in the Top tables
 METRIC_LABELS_BASE = [
     'ROAS', 'Inversión', 'Compras', 'Ventas', 'NCPA', 'CVR',
-    'AOV', 'Alcance', 'Impresiones', 'CTR'
+    'AOV', 'Alcance', 'Impresiones', 'CTR',
+    'Presupuesto Campaña', 'Presupuesto Adset', 'Objetivo', 'Tipo Compra', 'Estado Entrega'
 ]
 METRIC_LABELS_ADS = METRIC_LABELS_BASE + ['Frecuencia']
 
@@ -1208,6 +1209,11 @@ def _generar_tabla_bitacora_top_entities(
                 'Impresiones': fmt_int(key_row.get('impr')),
                 'CTR': fmt_pct(key_row.get('ctr'),2),
                 'Frecuencia': fmt_float(key_row.get('frequency'),2),
+                'Presupuesto Campaña': f"{detected_currency}{fmt_float(key_row.get('campaign_budget'),2)}" if key_row.get('campaign_budget') is not None else '-',
+                'Presupuesto Adset': f"{detected_currency}{fmt_float(key_row.get('adset_budget'),2)}" if key_row.get('adset_budget') is not None else '-',
+                'Objetivo': key_row.get('objective','-'),
+                'Tipo Compra': key_row.get('purchase_type','-'),
+                'Estado Entrega': key_row.get('delivery_general_status','-'),
             }
             metrics = {k: base_metrics.get(k, '-') for k in metric_labels}
 
@@ -1363,16 +1369,21 @@ def _generar_tabla_bitacora_entidad(entity_level, entity_name, df_daily_entity,
         'CPM': {'display':'CPM', 'formatter': lambda x: f"{detected_currency}{fmt_float(x, 2)}"},
         'Clics': {'display':'Clics (Link)', 'formatter': fmt_int},
         'CTR': {'display':'CTR (Link) %', 'formatter': lambda x: fmt_pct(x, 2)},
-        'Clics Salientes': {'display':'Clics (Out)', 'formatter': fmt_int}, 
-        'CTR Saliente': {'display':'CTR (Out) %', 'formatter': lambda x: fmt_pct(x, 2)}, 
+        'Clics Salientes': {'display':'Clics (Out)', 'formatter': fmt_int},
+        'CTR Saliente': {'display':'CTR (Out) %', 'formatter': lambda x: fmt_pct(x, 2)},
         'Visitas': {'display':'Visitas LP', 'formatter': fmt_int},
         'LVP_Rate_%': {'display':'Tasa Visita LP %', 'formatter': lambda x: fmt_pct(x, 1)},
         'Conv_Rate_%': {'display':'Tasa Compra %', 'formatter': lambda x: fmt_pct(x, 1)},
-        'Tiempo_Promedio': {'display':'Tiempo RV (s)', 'formatter': lambda x: fmt_float(x,1)}, 
+        'Tiempo_Promedio': {'display':'Tiempo RV (s)', 'formatter': lambda x: fmt_float(x,1)},
         'RV25_%': {'display': 'RV 25%','formatter': lambda x: fmt_pct(x, 1)},
         'RV75_%': {'display': 'RV 75%','formatter': lambda x: fmt_pct(x, 1)},
         'RV100_%': {'display': 'RV 100%','formatter': lambda x: fmt_pct(x, 1)},
-        'ROAS_Stability_%': {'display':'Est. ROAS %', 'formatter':fmt_stability}, 
+        'Presupuesto_Campana': {'display':'Presup. Campaña', 'formatter': lambda x: f"{detected_currency}{fmt_float(x,2)}"},
+        'Presupuesto_Adset': {'display':'Presup. Adset', 'formatter': lambda x: f"{detected_currency}{fmt_float(x,2)}"},
+        'Objetivo': {'display':'Objetivo', 'formatter': lambda x: str(x) if pd.notna(x) else '-'},
+        'Tipo_Compra': {'display':'Tipo Compra', 'formatter': lambda x: str(x) if pd.notna(x) else '-'},
+        'Estado_Entrega': {'display':'Estado Entrega', 'formatter': lambda x: str(x) if pd.notna(x) else '-'},
+        'ROAS_Stability_%': {'display':'Est. ROAS %', 'formatter':fmt_stability},
         'CPA_Stability_%': {'display':'Est. CPA %', 'formatter':fmt_stability},
         'CPM_Stability_%': {'display':'Est. CPM %', 'formatter':fmt_stability},
         'CTR_Stability_%': {'display':'Est. CTR %', 'formatter':fmt_stability},
@@ -1382,9 +1393,10 @@ def _generar_tabla_bitacora_entidad(entity_level, entity_name, df_daily_entity,
     order = [ 
         'Inversion', 'Ventas_Totales', 'ROAS', 'Compras', 'CPA', 'Ticket_Promedio',
         'Impresiones', 'Alcance', 'Frecuencia', 'CPM',
-        'Clics', 'CTR', 'Clics Salientes', 'CTR Saliente', 'Visitas', 'LVP_Rate_%', 'Conv_Rate_%', 
-        'Tiempo_Promedio', 'RV25_%', 'RV75_%', 'RV100_%', 
-        'ROAS_Stability_%', 'CPA_Stability_%', 'CPM_Stability_%', 'CTR_Stability_%', 'IMPR_Stability_%', 'CTR_DIV_FREQ_RATIO_Stability_%' 
+        'Presupuesto_Campana', 'Presupuesto_Adset', 'Objetivo', 'Tipo_Compra', 'Estado_Entrega',
+        'Clics', 'CTR', 'Clics Salientes', 'CTR Saliente', 'Visitas', 'LVP_Rate_%', 'Conv_Rate_%',
+        'Tiempo_Promedio', 'RV25_%', 'RV75_%', 'RV100_%',
+        'ROAS_Stability_%', 'CPA_Stability_%', 'CPM_Stability_%', 'CTR_Stability_%', 'IMPR_Stability_%', 'CTR_DIV_FREQ_RATIO_Stability_%'
     ]
     headers = ["Métrica"] + period_labels_for_table 
     rows = []

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -60,5 +60,10 @@ This document lists the columns present in the imported Excel reports and how th
 | Atencion | attention | numeric | mapped via `norm_map` |
 | Inicio del informe | - | date | not used |
 | Fin del informe | - | date | not used |
+| Estado de la entrega | delivery_general_status | string | mapped via `norm_map` |
+| presupuesto Campaña | campaign_budget | numeric | mapped via `norm_map` |
+| Presupuesto Adset | adset_budget | numeric | mapped via `norm_map` |
+| Objetivo | objective | string | mapped via `norm_map` |
+| Tipo de compra | purchase_type | string | mapped via `norm_map` |
 
 Only the columns explicitly mapped in `norm_map` are processed. The rest are currently ignored by the data loaders.

--- a/docs/excel_column_list.md
+++ b/docs/excel_column_list.md
@@ -59,4 +59,9 @@ Deseo
 Interes
 Inicio del informe
 Fin del informe
+Estado de la entrega
+presupuesto Campaña
+Presupuesto Adset
+Objetivo
+Tipo de compra
 ```

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import queue
+from data_processing.aggregators import _agregar_datos_diarios
+
+
+def test_aggregate_new_metrics():
+    df = pd.DataFrame({
+        'date': pd.to_datetime(['2025-06-01','2025-06-01']),
+        'Campaign': ['C1','C1'],
+        'AdSet': ['A1','A1'],
+        'Anuncio': ['Ad1','Ad1'],
+        'campaign_budget': [100, 100],
+        'adset_budget': [50, 60],
+        'objective': ['Ventas', 'Ventas'],
+        'purchase_type': ['Subasta', 'Subasta'],
+        'delivery_general_status': ['Activo', 'Activo'],
+    })
+    q = queue.SimpleQueue()
+    result = _agregar_datos_diarios(df, q)
+    assert 'campaign_budget' in result.columns
+    assert result['campaign_budget'].iloc[0] == 100
+    assert 'adset_budget' in result.columns
+    assert result['adset_budget'].iloc[0] == 55
+    assert 'objective' in result.columns
+    assert result['objective'].iloc[0] == 'Ventas'
+    assert 'purchase_type' in result.columns
+    assert 'delivery_general_status' in result.columns

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -19,3 +19,23 @@ def test_value_fallback_from_avg(tmp_path):
     expected = df['Valor de conversión de compras promedio'].iloc[1] * df['Compras'].iloc[1]
     assert result['value'].iloc[0] == expected
 
+
+def test_new_columns_mapping(tmp_path):
+    df = pd.DataFrame({
+        'Día': ['2025-06-01', '2025-06-02'],
+        'Nombre de la campaña': ['Camp', 'Camp'],
+        'Nombre del conjunto de anuncios': ['Set', 'Set'],
+        'Estado de la entrega': ['Activo', 'Activo'],
+        'presupuesto Campaña': [100, 100],
+        'Presupuesto Adset': [50, 50],
+        'Objetivo': ['Ventas', 'Ventas'],
+        'Tipo de compra': ['Subasta', 'Subasta'],
+    })
+    file_path = tmp_path / 'data2.xlsx'
+    df.to_excel(file_path, index=False)
+
+    q = queue.SimpleQueue()
+    result, _, _ = _cargar_y_preparar_datos([str(file_path)], q, '__ALL__')
+    for col in ['delivery_general_status','campaign_budget','adset_budget','objective','purchase_type']:
+        assert col in result.columns
+


### PR DESCRIPTION
## Summary
- map additional input columns in `config.py`
- handle new columns in loaders and aggregators
- compute and display budgets and objectives in reports
- document extra columns
- ensure new columns load and aggregate correctly with tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501f2cc8b88332b507a61c15566b56