### PR TITLE
Document and map delivery level column

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,6 +83,7 @@ norm_map = {
     'adset_budget': [normalize('Presupuesto Adset'), normalize('Presupuesto del conjunto de anuncios')],
     'objective': [normalize('Objetivo'), normalize('Objective')],
     'purchase_type': [normalize('Tipo de compra')],
+    'delivery_level': [normalize('Nivel de la entrega')],
 }
 
 numeric_internal_cols = [

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -65,5 +65,6 @@ This document lists the columns present in the imported Excel reports and how th
 | Presupuesto Adset | adset_budget | numeric | mapped via `norm_map` |
 | Objetivo | objective | string | mapped via `norm_map` |
 | Tipo de compra | purchase_type | string | mapped via `norm_map` |
+| Nivel de la entrega | delivery_level | string | mapped via `norm_map`; not used |
 
 Only the columns explicitly mapped in `norm_map` are processed. The rest are currently ignored by the data loaders.

--- a/docs/excel_column_list.md
+++ b/docs/excel_column_list.md
@@ -64,4 +64,5 @@ presupuesto Campaña
 Presupuesto Adset
 Objetivo
 Tipo de compra
+Nivel de la entrega
 ```

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -39,3 +39,18 @@ def test_new_columns_mapping(tmp_path):
     for col in ['delivery_general_status','campaign_budget','adset_budget','objective','purchase_type']:
         assert col in result.columns
 
+
+def test_delivery_level_mapping(tmp_path):
+    df = pd.DataFrame({
+        'Día': ['2025-06-01', '2025-06-02'],
+        'Nombre de la campaña': ['Camp', 'Camp'],
+        'Nombre del conjunto de anuncios': ['Set', 'Set'],
+        'Nivel de la entrega': ['Ad', 'Ad'],
+    })
+    file_path = tmp_path / 'data3.xlsx'
+    df.to_excel(file_path, index=False)
+
+    q = queue.SimpleQueue()
+    result, _, _ = _cargar_y_preparar_datos([str(file_path)], q, '__ALL__')
+    assert 'delivery_level' in result.columns
+


### PR DESCRIPTION
## Summary
- mention `Nivel de la entrega` in the Excel header list
- add documentation entry for the new column
- map new column as `delivery_level`
- test that loader handles the mapping

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850591d24888332824bddf333d28afd