### PR TITLE
Add audience metrics and ratio trends

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,6 +83,7 @@ norm_map = {
     'adset_budget': [normalize('Presupuesto Adset'), normalize('Presupuesto del conjunto de anuncios')],
     'objective': [normalize('Objetivo'), normalize('Objective')],
     'purchase_type': [normalize('Tipo de compra')],
+    'delivery_level': [normalize('Nivel de la entrega')],
 }
 
 numeric_internal_cols = [

--- a/data_processing/orchestrators.py
+++ b/data_processing/orchestrators.py
@@ -25,7 +25,8 @@ from .report_sections import (
     _generar_tabla_embudo_rendimiento, _generar_tabla_embudo_bitacora,
     _generar_analisis_ads, _generar_tabla_top_ads_historico,
     _generar_tabla_bitacora_entidad, _generar_tabla_bitacora_top_ads,
-    _generar_tabla_bitacora_top_adsets, _generar_tabla_bitacora_top_campaigns
+    _generar_tabla_bitacora_top_adsets, _generar_tabla_bitacora_top_campaigns,
+    _generar_tabla_performance_publico, _generar_tabla_tendencia_ratios
 )
 
 # Importaciones de módulos en la raíz del proyecto
@@ -488,6 +489,8 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
             _generar_tabla_bitacora_top_ads(df_daily_agg_full, bitacora_periods_list, active_days_ad, log, detected_currency, top_n=20)
             _generar_tabla_bitacora_top_adsets(df_daily_agg_full, bitacora_periods_list, active_days_adset, log, detected_currency)
             _generar_tabla_bitacora_top_campaigns(df_daily_agg_full, bitacora_periods_list, active_days_campaign, log, detected_currency)
+            _generar_tabla_performance_publico(df_daily_agg_full, log, detected_currency, top_n=5)
+            _generar_tabla_tendencia_ratios(df_daily_total_for_bitacora, bitacora_periods_list, log, period_type=bitacora_comparison_type)
 
             log("\n\n============================================================");log(f"===== Resumen del Proceso (Bitácora {bitacora_comparison_type}) =====");log("============================================================")
             if log_summary_messages_orchestrator: [log(f"  - {re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip().replace('---','-')}") for msg in log_summary_messages_orchestrator if re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip()]

--- a/data_processing/report_sections.py
+++ b/data_processing/report_sections.py
@@ -1298,6 +1298,126 @@ def _generar_tabla_bitacora_top_campaigns(df_daily_agg, bitacora_periods_list, a
     log_func("  ---")
 
 
+def _generar_tabla_performance_publico(df_daily_agg, log_func, detected_currency, top_n=5):
+    """Construye tabla con métricas de rendimiento por público."""
+
+    log_func("\n\n============================================================")
+    log_func(f"===== Performance Público (Top {top_n}) =====")
+    log_func("============================================================")
+
+    if df_daily_agg is None or df_daily_agg.empty or 'Públicos In' not in df_daily_agg.columns:
+        log_func("No hay datos de públicos para analizar.")
+        return
+
+    df_aud = df_daily_agg.copy()
+    df_aud['publico'] = df_aud['Públicos In'].apply(_clean_audience_string)
+    df_aud['publico'] = df_aud['publico'].replace({'': '(Sin Público)', '-': '(Sin Público)'})
+
+    agg_cols = {col: 'sum' for col in ['spend', 'purchases', 'value', 'impr', 'clicks', 'reach'] if col in df_aud.columns}
+    if not agg_cols:
+        log_func("No hay columnas métricas para públicos.")
+        return
+
+    df_group = df_aud.groupby('publico', as_index=False).agg(agg_cols)
+
+    if 'value' in df_group.columns and 'spend' in df_group.columns:
+        df_group['roas'] = safe_division(df_group['value'], df_group['spend'])
+    if 'spend' in df_group.columns and 'impr' in df_group.columns:
+        df_group['cpm'] = safe_division(df_group['spend'], df_group['impr']) * 1000
+    if 'clicks' in df_group.columns and 'impr' in df_group.columns:
+        df_group['ctr'] = safe_division_pct(df_group['clicks'], df_group['impr'])
+    if 'spend' in df_group.columns and 'purchases' in df_group.columns:
+        df_group['cpa'] = safe_division(df_group['spend'], df_group['purchases'])
+
+    df_group = df_group.sort_values('spend', ascending=False).head(top_n)
+
+    rename_map = {
+        'publico': 'Público',
+        'spend': 'Spend',
+        'purchases': 'Compras',
+        'roas': 'ROAS',
+        'cpm': 'CPM',
+        'ctr': 'CTR',
+        'cpa': 'CPA',
+        'reach': 'Alcance',
+    }
+    df_disp = df_group.rename(columns=rename_map)
+    col_order = [c for c in ['Público','Spend','Compras','ROAS','CPM','CTR','CPA','Alcance'] if c in df_disp.columns]
+    df_disp = df_disp[col_order]
+
+    num_cols = [c for c in df_disp.columns if c != 'Público']
+    pct_cols = {'CTR': 2}
+    float_cols = {'ROAS': 2, 'CPM': 2}
+    currency_cols = {'Spend': detected_currency, 'CPA': detected_currency}
+
+    _format_dataframe_to_markdown(
+        df_disp,
+        f"TABLA: PERFORMANCE_PUBLICO",
+        log_func,
+        float_cols_fmt=float_cols,
+        pct_cols_fmt=pct_cols,
+        currency_cols=currency_cols,
+        int_cols=[c for c in df_disp.columns if c in ['Compras','Alcance']],
+        numeric_cols_for_alignment=num_cols,
+    )
+
+
+def _generar_tabla_tendencia_ratios(df_daily_total, bitacora_periods_list, log_func, period_type="Weeks"):
+    """Genera tabla de tendencia de ratios por periodo."""
+
+    header_label = 'Semana' if period_type == 'Weeks' else 'Mes'
+
+    log_func("\n\n============================================================")
+    log_func(f"===== Tendencia Ratios ({'Semanal' if period_type == 'Weeks' else 'Mensual'}) =====")
+    log_func("============================================================")
+
+    if df_daily_total is None or df_daily_total.empty or 'date' not in df_daily_total.columns:
+        log_func("No hay datos para calcular tendencias.")
+        return
+
+    metric_cols = ['clicks', 'impr', 'visits', 'addcart', 'checkout', 'purchases']
+    if not any(col in df_daily_total.columns for col in metric_cols):
+        log_func("No hay columnas suficientes para calcular ratios.")
+        return
+
+    rows = []
+    for start_dt, end_dt, label in bitacora_periods_list:
+        df_p = df_daily_total[
+            (df_daily_total['date'].dt.date >= start_dt.date()) &
+            (df_daily_total['date'].dt.date <= end_dt.date())
+        ]
+        clicks = df_p.get('clicks', pd.Series(dtype=float)).sum()
+        impr = df_p.get('impr', pd.Series(dtype=float)).sum()
+        visits = df_p.get('visits', pd.Series(dtype=float)).sum()
+        addcart = df_p.get('addcart', pd.Series(dtype=float)).sum()
+        checkout = df_p.get('checkout', pd.Series(dtype=float)).sum()
+        purchases = df_p.get('purchases', pd.Series(dtype=float)).sum()
+
+        ctr = safe_division_pct(clicks, impr)
+        cvr_lp_cart = safe_division_pct(addcart, visits)
+        cvr_cart_checkout = safe_division_pct(checkout, addcart)
+        cvr_checkout_purchase = safe_division_pct(purchases, checkout)
+
+        rows.append({
+            header_label: label,
+            'CTR': ctr,
+            'CVR LP→Cart': cvr_lp_cart,
+            'CVR Cart→Checkout': cvr_cart_checkout,
+            'CVR Checkout→Compra': cvr_checkout_purchase,
+        })
+
+    df_disp = pd.DataFrame(rows)
+    pct_cols = {c: 2 for c in df_disp.columns if c != header_label}
+
+    _format_dataframe_to_markdown(
+        df_disp,
+        f"TABLA: TENDENCIA_RATIOS",
+        log_func,
+        pct_cols_fmt=pct_cols,
+        numeric_cols_for_alignment=list(pct_cols.keys()),
+    )
+
+
 def _generar_tabla_bitacora_entidad(entity_level, entity_name, df_daily_entity,
                                    bitacora_periods_list, detected_currency, log_func, period_type="Weeks"):
     """Build a period-over-period table for a single entity within the report."""

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -65,5 +65,6 @@ This document lists the columns present in the imported Excel reports and how th
 | Presupuesto Adset | adset_budget | numeric | mapped via `norm_map` |
 | Objetivo | objective | string | mapped via `norm_map` |
 | Tipo de compra | purchase_type | string | mapped via `norm_map` |
+| Nivel de la entrega | delivery_level | string | mapped via `norm_map`; not used |
 
 Only the columns explicitly mapped in `norm_map` are processed. The rest are currently ignored by the data loaders.

--- a/docs/excel_column_list_bitacora.md
+++ b/docs/excel_column_list_bitacora.md
@@ -1,6 +1,7 @@
-# Excel Column Names
+# Excel Column Names (Bitacora)
 
-This list records the exact column names present in the example file `Informe-Maran-IA (11).xlsx`. Future datasets should provide the same or similar columns. Accents and punctuation are kept as in the file to avoid ambiguities.
+This list records the column names from the file `Informe-Bitacora-FINAL (1).xlsx`.
+They appear in the order provided by that document.
 
 ```
 Nombre de la campaña
@@ -14,7 +15,6 @@ Entrega del anuncio
 Impresiones
 Alcance
 Frecuencia
-Valor de conversión de compras
 Valor de conversión de compras promedio
 Compras
 Visitas a la página de destino
@@ -57,12 +57,11 @@ Divisa
 Atencion
 Deseo
 Interes
-Inicio del informe
-Fin del informe
+Valor de conversión de compras
 Estado de la entrega
-presupuesto Campaña
-Presupuesto Adset
+Nivel de la entrega
 Objetivo
 Tipo de compra
-Nivel de la entrega
+Inicio del informe
+Fin del informe
 ```

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -39,3 +39,18 @@ def test_new_columns_mapping(tmp_path):
     for col in ['delivery_general_status','campaign_budget','adset_budget','objective','purchase_type']:
         assert col in result.columns
 
+
+def test_delivery_level_mapping(tmp_path):
+    df = pd.DataFrame({
+        'Día': ['2025-06-01', '2025-06-02'],
+        'Nombre de la campaña': ['Camp', 'Camp'],
+        'Nombre del conjunto de anuncios': ['Set', 'Set'],
+        'Nivel de la entrega': ['Ad', 'Ad'],
+    })
+    file_path = tmp_path / 'data3.xlsx'
+    df.to_excel(file_path, index=False)
+
+    q = queue.SimpleQueue()
+    result, _, _ = _cargar_y_preparar_datos([str(file_path)], q, '__ALL__')
+    assert 'delivery_level' in result.columns
+

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -7,6 +7,8 @@ from data_processing.report_sections import (
     _generar_tabla_bitacora_top_entities,
     METRIC_LABELS_ADS,
     METRIC_LABELS_BASE,
+    _generar_tabla_performance_publico,
+    _generar_tabla_tendencia_ratios
 )
 from data_processing.report_sections import _clean_audience_string
 
@@ -208,4 +210,41 @@ def test_generic_helper_ads(capsys):
     )
     output = "\n".join(logs)
     assert 'Top 1 Ads Bitácora - Semana actual' in output
+
+
+def test_performance_publico_table():
+    df = pd.DataFrame({
+        'Públicos In': ['Aud1', 'Aud1', 'Aud2'],
+        'spend': [10, 15, 5],
+        'purchases': [1, 2, 0],
+        'value': [20, 40, 0],
+        'impr': [100, 200, 50],
+        'clicks': [5, 10, 2],
+        'reach': [80, 150, 30],
+        'date': pd.to_datetime(['2024-06-01', '2024-06-02', '2024-06-01']),
+    })
+    logs = []
+    _generar_tabla_performance_publico(df, logs.append, '$', top_n=2)
+    output = "\n".join(logs)
+    assert 'TABLA: PERFORMANCE_PUBLICO' in output
+
+
+def test_tendencia_ratios_weekly():
+    df = pd.DataFrame({
+        'date': pd.to_datetime(['2024-06-01', '2024-06-02', '2024-05-26']),
+        'clicks': [10, 5, 4],
+        'impr': [100, 80, 50],
+        'visits': [20, 15, 10],
+        'addcart': [5, 3, 2],
+        'checkout': [2, 1, 1],
+        'purchases': [1, 0, 1],
+    })
+    periods = [
+        (datetime(2024, 6, 1), datetime(2024, 6, 2), 'Semana actual'),
+        (datetime(2024, 5, 26), datetime(2024, 5, 26), '1ª semana anterior'),
+    ]
+    logs = []
+    _generar_tabla_tendencia_ratios(df, periods, logs.append, period_type='Weeks')
+    output = "\n".join(logs)
+    assert 'TABLA: TENDENCIA_RATIOS' in output
 


### PR DESCRIPTION
## Summary
- implement Performance Público and Tendencia Ratios tables
- hook new tables into Bitácora report generation
- test new tables

## Testing
- `pip install pandas numpy openpyxl`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850591d24888332824bddf333d28afd