### PR TITLE
Add audience metrics and ratio trends

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,6 +83,7 @@ norm_map = {
     'adset_budget': [normalize('Presupuesto Adset'), normalize('Presupuesto del conjunto de anuncios')],
     'objective': [normalize('Objetivo'), normalize('Objective')],
     'purchase_type': [normalize('Tipo de compra')],
+    'delivery_level': [normalize('Nivel de la entrega')],
 }
 
 numeric_internal_cols = [

--- a/data_processing/orchestrators.py
+++ b/data_processing/orchestrators.py
@@ -25,7 +25,8 @@ from .report_sections import (
     _generar_tabla_embudo_rendimiento, _generar_tabla_embudo_bitacora,
     _generar_analisis_ads, _generar_tabla_top_ads_historico,
     _generar_tabla_bitacora_entidad, _generar_tabla_bitacora_top_ads,
-    _generar_tabla_bitacora_top_adsets, _generar_tabla_bitacora_top_campaigns
+    _generar_tabla_bitacora_top_adsets, _generar_tabla_bitacora_top_campaigns,
+    _generar_tabla_performance_publico, _generar_tabla_tendencia_ratios
 )
 
 # Importaciones de módulos en la raíz del proyecto
@@ -87,9 +88,10 @@ def procesar_reporte_rendimiento(input_files, output_dir, output_filename, statu
             active_days_adset = active_days_results.get('AdSet',pd.DataFrame())
             active_days_ad = active_days_results.get('Anuncio',pd.DataFrame())
             
-            last_day_status_lookup=pd.DataFrame(); max_date_global=None
+            last_day_status_lookup=pd.DataFrame(); max_date_global=None; min_date_global=None
             if not df_combined.empty and 'date' in df_combined.columns and pd.api.types.is_datetime64_any_dtype(df_combined['date']) and not df_combined['date'].dropna().empty:
                 max_date_global = df_combined['date'].max()
+                min_date_global = df_combined['date'].min()
                 if pd.notna(max_date_global):
                     status_cols=['ad_delivery_status','adset_delivery_status','campaign_delivery_status', 'entrega']
                     group_cols=['Campaign','AdSet','Anuncio']
@@ -187,6 +189,18 @@ def procesar_reporte_rendimiento(input_files, output_dir, output_filename, statu
             else: log("  No se generaron mensajes de resumen.")
             log("============================================================")
             log("\n\n--- FIN DEL REPORTE RENDIMIENTO ---",importante=True); status_queue.put("---DONE---")
+
+            try:
+                if max_date_global is not None and min_date_global is not None:
+                    start_label = min_date_global.strftime('%Y%m%d')
+                    end_label = max_date_global.strftime('%Y%m%d')
+                    base, ext = os.path.splitext(output_filename)
+                    new_name = f"{base}_{start_label}-{end_label}{ext}"
+                    new_path = os.path.join(output_dir, new_name)
+                    os.replace(output_path, new_path)
+                    log(f"Archivo renombrado a {new_name}")
+            except Exception as ren_err:
+                log(f"Adv: no se pudo renombrar archivo: {ren_err}")
     except Exception as e_main:
         error_details=traceback.format_exc(); log_msg=f"!!! Error Fatal General Reporte Rendimiento: {e_main} !!!\n{error_details}";
         log(log_msg,importante=True)
@@ -488,12 +502,26 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
             _generar_tabla_bitacora_top_ads(df_daily_agg_full, bitacora_periods_list, active_days_ad, log, detected_currency, top_n=20)
             _generar_tabla_bitacora_top_adsets(df_daily_agg_full, bitacora_periods_list, active_days_adset, log, detected_currency)
             _generar_tabla_bitacora_top_campaigns(df_daily_agg_full, bitacora_periods_list, active_days_campaign, log, detected_currency)
+            _generar_tabla_performance_publico(df_daily_agg_full, log, detected_currency, top_n=5)
+            _generar_tabla_tendencia_ratios(df_daily_total_for_bitacora, bitacora_periods_list, log, period_type=bitacora_comparison_type)
 
             log("\n\n============================================================");log(f"===== Resumen del Proceso (Bitácora {bitacora_comparison_type}) =====");log("============================================================")
             if log_summary_messages_orchestrator: [log(f"  - {re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip().replace('---','-')}") for msg in log_summary_messages_orchestrator if re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip()]
             else: log("  No se generaron mensajes de resumen.")
             log("============================================================")
             log(f"\n\n--- FIN DEL REPORTE BITÁCORA ({bitacora_comparison_type}) ---", importante=True); status_queue.put("---DONE---")
+
+            try:
+                if bitacora_periods_list:
+                    start_label = bitacora_periods_list[0][0].strftime('%Y%m%d')
+                    end_label = bitacora_periods_list[0][1].strftime('%Y%m%d')
+                    base, ext = os.path.splitext(output_filename)
+                    new_name = f"{base}_{start_label}-{end_label}{ext}"
+                    new_path = os.path.join(output_dir, new_name)
+                    os.replace(output_path, new_path)
+                    log(f"Archivo renombrado a {new_name}")
+            except Exception as ren_err:
+                log(f"Adv: no se pudo renombrar archivo: {ren_err}")
 
     except Exception as e_main_bitacora:
         error_details = traceback.format_exc()

--- a/docs/column_reference.md
+++ b/docs/column_reference.md
@@ -65,5 +65,6 @@ This document lists the columns present in the imported Excel reports and how th
 | Presupuesto Adset | adset_budget | numeric | mapped via `norm_map` |
 | Objetivo | objective | string | mapped via `norm_map` |
 | Tipo de compra | purchase_type | string | mapped via `norm_map` |
+| Nivel de la entrega | delivery_level | string | mapped via `norm_map`; not used |
 
 Only the columns explicitly mapped in `norm_map` are processed. The rest are currently ignored by the data loaders.

--- a/docs/excel_column_list_bitacora.md
+++ b/docs/excel_column_list_bitacora.md
@@ -1,6 +1,7 @@
-# Excel Column Names
+# Excel Column Names (Bitacora)
 
-This list records the exact column names present in the example file `Informe-Maran-IA (11).xlsx`. Future datasets should provide the same or similar columns. Accents and punctuation are kept as in the file to avoid ambiguities.
+This list records the column names from the file `Informe-Bitacora-FINAL (1).xlsx`.
+They appear in the order provided by that document.
 
 ```
 Nombre de la campaña
@@ -14,7 +15,6 @@ Entrega del anuncio
 Impresiones
 Alcance
 Frecuencia
-Valor de conversión de compras
 Valor de conversión de compras promedio
 Compras
 Visitas a la página de destino
@@ -57,12 +57,11 @@ Divisa
 Atencion
 Deseo
 Interes
-Inicio del informe
-Fin del informe
+Valor de conversión de compras
 Estado de la entrega
-presupuesto Campaña
-Presupuesto Adset
+Nivel de la entrega
 Objetivo
 Tipo de compra
-Nivel de la entrega
+Inicio del informe
+Fin del informe
 ```

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -39,3 +39,18 @@ def test_new_columns_mapping(tmp_path):
     for col in ['delivery_general_status','campaign_budget','adset_budget','objective','purchase_type']:
         assert col in result.columns
 
+
+def test_delivery_level_mapping(tmp_path):
+    df = pd.DataFrame({
+        'Día': ['2025-06-01', '2025-06-02'],
+        'Nombre de la campaña': ['Camp', 'Camp'],
+        'Nombre del conjunto de anuncios': ['Set', 'Set'],
+        'Nivel de la entrega': ['Ad', 'Ad'],
+    })
+    file_path = tmp_path / 'data3.xlsx'
+    df.to_excel(file_path, index=False)
+
+    q = queue.SimpleQueue()
+    result, _, _ = _cargar_y_preparar_datos([str(file_path)], q, '__ALL__')
+    assert 'delivery_level' in result.columns
+

--- a/tests/test_report_sections.py
+++ b/tests/test_report_sections.py
@@ -7,6 +7,8 @@ from data_processing.report_sections import (
     _generar_tabla_bitacora_top_entities,
     METRIC_LABELS_ADS,
     METRIC_LABELS_BASE,
+    _generar_tabla_performance_publico,
+    _generar_tabla_tendencia_ratios
 )
 from data_processing.report_sections import _clean_audience_string
 
@@ -55,6 +57,10 @@ def test_top_ads_basic_columns(capsys):
     assert 'Anuncio' in output
     assert 'Días Act' in output
     assert 'Ventas' in output
+    assert 'RV25%' in output
+    assert 'RV75%' in output
+    assert 'RV100%' in output
+    assert 'Tiempo RV (s)' in output
 
 def test_clean_audience_string():
     assert _clean_audience_string('123:Aud1 | 456:Aud2') == 'Aud1, Aud2'
@@ -208,4 +214,41 @@ def test_generic_helper_ads(capsys):
     )
     output = "\n".join(logs)
     assert 'Top 1 Ads Bitácora - Semana actual' in output
+
+
+def test_performance_publico_table():
+    df = pd.DataFrame({
+        'Públicos In': ['Aud1', 'Aud1', 'Aud2'],
+        'spend': [10, 15, 5],
+        'purchases': [1, 2, 0],
+        'value': [20, 40, 0],
+        'impr': [100, 200, 50],
+        'clicks': [5, 10, 2],
+        'reach': [80, 150, 30],
+        'date': pd.to_datetime(['2024-06-01', '2024-06-02', '2024-06-01']),
+    })
+    logs = []
+    _generar_tabla_performance_publico(df, logs.append, '$', top_n=2)
+    output = "\n".join(logs)
+    assert 'TABLA: PERFORMANCE_PUBLICO' in output
+
+
+def test_tendencia_ratios_weekly():
+    df = pd.DataFrame({
+        'date': pd.to_datetime(['2024-06-01', '2024-06-02', '2024-05-26']),
+        'clicks': [10, 5, 4],
+        'impr': [100, 80, 50],
+        'visits': [20, 15, 10],
+        'addcart': [5, 3, 2],
+        'checkout': [2, 1, 1],
+        'purchases': [1, 0, 1],
+    })
+    periods = [
+        (datetime(2024, 6, 1), datetime(2024, 6, 2), 'Semana actual'),
+        (datetime(2024, 5, 26), datetime(2024, 5, 26), '1ª semana anterior'),
+    ]
+    logs = []
+    _generar_tabla_tendencia_ratios(df, periods, logs.append, period_type='Weeks')
+    output = "\n".join(logs)
+    assert 'TABLA: TENDENCIA_RATIOS' in output
 


### PR DESCRIPTION
## Summary
- implement Performance Público and Tendencia Ratios tables
- hook new tables into Bitácora report generation
- test new tables
- include video metrics in Top Ads tables
- rename generated reports with their date range

## Testing
- `pip install pandas numpy openpyxl`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850591d24888332824bddf333d28afd